### PR TITLE
Create momcozy_white_noise_machine_v2.yaml

### DIFF
--- a/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
+++ b/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
@@ -1,0 +1,300 @@
+name: White Noise Machine
+products:
+  - id: dymvl7axplliptxx
+    name: Mom Cozy White Noise, v2 with child lock and full timer
+primary_entity:
+  entity: light
+  dps:
+    - id: 3
+      type: boolean
+      name: switch
+    - id: 4
+      type: string
+      name: color_mode
+      mapping:
+        - dps_val: change
+          value: Rainbow
+        - dps_val: breath
+          value: Breath
+        - dps_val: light_off
+          value: hs
+        - dps_val: light_on
+          value: white
+    - id: 6
+      name: brightness
+      type: integer
+      optional: true
+      range:
+        min: 10
+        max: 1000
+      mapping:
+        - scale: 3.92
+    - id: 5
+      name: rgbhsv
+      type: hex
+      optional: true
+      format:
+        - name: h
+          bytes: 2
+          range:
+            min: 0
+            max: 360
+        - name: s
+          bytes: 2
+          range:
+            min: 0
+            max: 1000
+        - name: v
+          bytes: 2
+          range:
+            min: 0
+            max: 1000
+secondary_entities:
+  - entity: siren
+    name: Sound
+    icon: "mdi:music"
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+      - id: 9
+        name: volume_level
+        type: integer
+        range:
+          min: 10
+          max: 100
+        mapping:
+          - scale: 100
+      - id: 10
+        name: tone
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: White noise
+          - dps_val: "2"
+            value: Pink noise
+          - dps_val: "3"
+            value: Brown noise
+          - dps_val: "4"
+            value: Wall fan
+          - dps_val: "5"
+            value: Fan
+          - dps_val: "6"
+            value: Floor fan
+          - dps_val: "7"
+            value: Wind
+          - dps_val: "8"
+            value: Rain on roof
+          - dps_val: "9"
+            value: Rain
+          - dps_val: "10"
+            value: Thunderstorm
+          - dps_val: "11"
+            value: Light rain
+          - dps_val: "12"
+            value: Ocean wave
+          - dps_val: "13"
+            value: Water stream
+          - dps_val: "14"
+            value: Birds
+          - dps_val: "15"
+            value: Crickets
+          - dps_val: "16"
+            value: Frog
+          - dps_val: "17"
+            value: Fireplace
+          - dps_val: "18"
+            value: Campfire
+          - dps_val: "19"
+            value: Womb
+          - dps_val: "20"
+            value: Shushing
+          - dps_val: "21"
+            value: Cafe
+          - dps_val: "22"
+            value: Maracas
+          - dps_val: "23"
+            value: Clock
+          - dps_val: "24"
+            value: Buddha
+          - dps_val: "25"
+            value: Wind chimes
+          - dps_val: "26"
+            value: Steamship
+          - dps_val: "27"
+            value: Aircraft
+          - dps_val: "28"
+            value: Train
+          - dps_val: "29"
+            value: Lullaby
+          - dps_val: "30"
+            value: Music box
+          - dps_val: "31"
+            value: Twinkle little star
+          - dps_val: "32"
+            value: Good morning
+          - dps_val: "33"
+            value: Fantasy
+          - dps_val: "34"
+            value: Joyful
+      - id: 20
+        name: duration
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 1440
+  - entity: select
+    name: Favorites
+    icon: "mdi:palette"
+    category: config
+    dps:
+      - id: 13
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: mode_1
+            value: Scene 1
+          - dps_val: mode_2
+            value: Scene 2
+          - dps_val: mode_3
+            value: Scene 3
+          - dps_val: mode_4
+            value: Scene 4
+          - dps_val: mode_5
+            value: Scene 5
+          - dps_val: mode_6
+            value: Scene 6
+          - dps_val: mode_7
+            value: Scene 7
+          - dps_val: mode_8
+            value: Scene 8
+          - dps_val: null
+            value: None
+  - entity: number
+    name: Volume
+    category: config
+    icon: "mdi:volume-source"
+    dps:
+      - id: 9
+        type: integer
+        name: value
+        unit: "%"
+        range:
+          min: 10
+          max: 100
+  - entity: lock
+    name: Child Lock
+    category: config
+    dps:
+      - id: 101
+        name: lock
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: true
+            icon: "mdi:hand-back-right-off"
+          - dps_val: false
+            icon: "mdi:hand-back-right"
+  - entity: number
+    name: Timer
+    category: config
+    icon: "mdi:timer"
+    mode: box
+    dps:
+      - id: 20
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 1440
+  - entity: sensor
+    name: Timer Remaining
+    class: duration
+    readonly: true
+    dps:
+      - id: 104
+        name: sensor
+        type: string
+        unit: "s"
+        optional: true
+  - entity: select
+    name: Tone
+    icon: "mdi:waveform"
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "1"
+            value: White noise
+          - dps_val: "2"
+            value: Pink noise
+          - dps_val: "3"
+            value: Brown noise
+          - dps_val: "4"
+            value: Wall fan
+          - dps_val: "5"
+            value: Fan
+          - dps_val: "6"
+            value: Floor fan
+          - dps_val: "7"
+            value: Wind
+          - dps_val: "8"
+            value: Rain on roof
+          - dps_val: "9"
+            value: Rain
+          - dps_val: "10"
+            value: Thunderstorm
+          - dps_val: "11"
+            value: Light rain
+          - dps_val: "12"
+            value: Ocean wave
+          - dps_val: "13"
+            value: Water stream
+          - dps_val: "14"
+            value: Birds
+          - dps_val: "15"
+            value: Crickets
+          - dps_val: "16"
+            value: Frog
+          - dps_val: "17"
+            value: Fireplace
+          - dps_val: "18"
+            value: Campfire
+          - dps_val: "19"
+            value: Womb
+          - dps_val: "20"
+            value: Shushing
+          - dps_val: "21"
+            value: Cafe
+          - dps_val: "22"
+            value: Maracas
+          - dps_val: "23"
+            value: Clock
+          - dps_val: "24"
+            value: Buddha
+          - dps_val: "25"
+            value: Wind chimes
+          - dps_val: "26"
+            value: Steamship
+          - dps_val: "27"
+            value: Aircraft
+          - dps_val: "28"
+            value: Train
+          - dps_val: "29"
+            value: Lullaby
+          - dps_val: "30"
+            value: Music box
+          - dps_val: "31"
+            value: Twinkle little star
+          - dps_val: "32"
+            value: Good morning
+          - dps_val: "33"
+            value: Fantasy
+          - dps_val: "34"
+            value: Joyful

--- a/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
+++ b/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
@@ -1,4 +1,4 @@
-name: White Noise Machine
+name: White noise machine
 products:
   - id: dymvl7axplliptxx
     name: Mom Cozy White Noise, v2 with child lock and full timer


### PR DESCRIPTION
Add support for Mom Cozy White Noise machine, v1.
https://www.amazon.com/Machine-Momcozy-Sleeping-Soothing-Personal/dp/B099RSXLGH

This is v2 which does NOT support for Alexa and Google Home. It has a child lock available, as well as a timer that can be configured on a per minute basis up to 1440 minutes. Favorite settings (aka Scenes) are done on DPS 13, compared to v1 where Scenes are done on DPS 12.

DPS mappings as such:
````{"1":"Switch","2":"Work Mode","3":"Light Switch","4":"Light Mode","5":"Light Color","6":"Brightness","8":"Music Switch","9":"Volume","10":"Music","11":"Music","13":"Scene","14":"Customize Scene Set","15":"Wake Up Set","16":"Sleep Aid Set","18":"Alarm Stop","19":"Status","20":"Timer","101":"Child Lock","102":"行程启动","103":"预览模式","104":"倒计时时间上报","105":"启用预设"}````

Translations:
102: Trip Start
103: Preview Mode
104: Countdown Time Report
105: Enable Preset